### PR TITLE
CentOS 8 PHP 7.2 configuration example

### DIFF
--- a/centos-8/examples/php-7-2/config.json.example
+++ b/centos-8/examples/php-7-2/config.json.example
@@ -10,7 +10,7 @@
     "projects": [],
     "project_scripts": [],
     "provision_privileged_scripts": [
-        "sql-server.sh"
+        "base.sh"
     ],
     "provision_scripts": [],
     "synced_folders": [

--- a/centos-8/examples/php-7-2/config.json.example
+++ b/centos-8/examples/php-7-2/config.json.example
@@ -11,7 +11,8 @@
     "project_scripts": [],
     "provision_privileged_scripts": [
         "base.sh",
-        "apache/apache.sh"
+        "apache/apache.sh",
+        "centos-8/php/7-2.sh"
     ],
     "provision_scripts": [],
     "synced_folders": [

--- a/centos-8/examples/php-7-2/config.json.example
+++ b/centos-8/examples/php-7-2/config.json.example
@@ -10,7 +10,8 @@
     "projects": [],
     "project_scripts": [],
     "provision_privileged_scripts": [
-        "base.sh"
+        "base.sh",
+        "apache/apache.sh"
     ],
     "provision_scripts": [],
     "synced_folders": [

--- a/scripts/centos-8/php/7-2.sh
+++ b/scripts/centos-8/php/7-2.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Install and Configure PHP 7.2
+
+# Install PHP and its extensions
+yum -y install php php-opcache php-bcmath php-xml php-gd php-devel php-mysqlnd php-intl php-mbstring php-soap php-pgsql
+
+# Start the FPM service and enable it to automatically start on boot
+systemctl enable --now php-fpm
+
+# Restart Apache
+systemctl restart httpd
+
+# Set display_errors = On
+sed -i 's"^display_errors =.*$"display_errors = On"' /etc/php.ini
+
+# Set upload_max_filesize = 256M
+sed -i 's"^upload_max_filesize =.*$"upload_max_filesize = 256M"' /etc/php.ini
+
+# Set post_max_size = 100M
+sed -i 's"^post_max_size =.*$"post_max_size = 100M"' /etc/php.ini
+
+# Set date.timezone = Europe/London
+sed -i 's"^;date\.timezone =.*$"date.timezone = Europe/London"' /etc/php.ini
+
+# Set sendmail_path = /usr/sbin/ssmtp -t
+sed -i 's"^sendmail_path =.*$"sendmail_path = /usr/sbin/ssmtp -t"' /etc/php.ini

--- a/scripts/centos-8/php/7-2.sh
+++ b/scripts/centos-8/php/7-2.sh
@@ -8,9 +8,6 @@ yum -y install php php-opcache php-bcmath php-xml php-gd php-devel php-mysqlnd p
 # Start the FPM service and enable it to automatically start on boot
 systemctl enable --now php-fpm
 
-# Restart Apache
-systemctl restart httpd
-
 # Set display_errors = On
 sed -i 's"^display_errors =.*$"display_errors = On"' /etc/php.ini
 
@@ -25,3 +22,6 @@ sed -i 's"^;date\.timezone =.*$"date.timezone = Europe/London"' /etc/php.ini
 
 # Set sendmail_path = /usr/sbin/ssmtp -t
 sed -i 's"^sendmail_path =.*$"sendmail_path = /usr/sbin/ssmtp -t"' /etc/php.ini
+
+# Restart Apache
+systemctl restart httpd

--- a/scripts/centos-8/php/7-4.sh
+++ b/scripts/centos-8/php/7-4.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Install and Configure PHP 7.4
+
+# Enable the Remi repository
+dnf install -y dnf-utils http://rpms.remirepo.net/enterprise/remi-release-8.rpm
+
+# Enable PHP 7.4 for install
+dnf module reset php
+dnf module enable -y php:remi-7.4
+
+# Install PHP and its extensions
+dnf install -y php php-opcache php-bcmath php-xml php-gd php-mysqlnd php-intl php-mbstring php-soap php-pgsql
+
+# Start the FPM service and enable it to automatically start on boot
+systemctl enable --now php-fpm
+
+# Set display_errors = On
+sed -i 's"^display_errors =.*$"display_errors = On"' /etc/php.ini
+
+# Set upload_max_filesize = 256M
+sed -i 's"^upload_max_filesize =.*$"upload_max_filesize = 256M"' /etc/php.ini
+
+# Set post_max_size = 100M
+sed -i 's"^post_max_size =.*$"post_max_size = 100M"' /etc/php.ini
+
+# Set date.timezone = Europe/London
+sed -i 's"^;date\.timezone =.*$"date.timezone = Europe/London"' /etc/php.ini
+
+# Set sendmail_path = /usr/sbin/ssmtp -t
+sed -i 's"^sendmail_path =.*$"sendmail_path = /usr/sbin/ssmtp -t"' /etc/php.ini
+
+# Restart Apache
+systemctl restart httpd


### PR DESCRIPTION
This PR aims at testing the existing scripts for CentOS 7, against CentOS 8, and amend them, providing a sensible `config.json.example` file for a CentOS 8 machine with PHP 7.2